### PR TITLE
Connection close codes and reason support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ want to add WebSocket support to existing HTTP APIs without modifying the backen
 handles the protocol translation and message routing, making it an ideal solution for scenarios requiring real-time
 updates in HTTP-based architectures.
 
-## Usage```shell
+## Usage
+
+```shell
 ws2wh -b https://example.com/api/v1/webhook -r /reply -l :3000 -p / -v INFO -h localhost
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,19 @@ The backend can respond in two ways:
 
 Any response body in the 200-299 range will be forwarded back to the WebSocket client immediately.
 
+```http
+HTTP/1.1 200 OK
+Ws-Command: terminate-session
+Ws-Close-Code: 1001
+Ws-Close-Reason: Closing connection
+Content-Length: 0
+```
+
 #### 2.2 Async Reply
 
 The backend can send messages later using the reply channel URL provided in `Ws-Reply-Channel` header:
 
-```
+```http
 POST <reply-channel-url>
 Content-Type: text/plain
 
@@ -197,7 +205,8 @@ Goodbye!
 
 In the example above, the backend server would send a `Ws-Command: terminate-session` header to a session reply
 channel. The WebSocket session, along with the connection, will be closed gracefully with code 1000 by default.
-Close code and reason can be customized by providing `Ws-Close-Code` and `Ws-Close-Reason` headers.
+The close code and reason can be customized by providing `Ws-Close-Code` and `Ws-Close-Reason` headers. These headers
+are only honored when combined with `Ws-Command: terminate-session`.
 
 ```http
 POST /reply/550e8400-e29b-41d4-a716-446655440000 HTTP/1.1

--- a/README.md
+++ b/README.md
@@ -181,3 +181,16 @@ Content-Length: 10
 
 Goodbye!
 ```
+
+In the example above, the backend server would send a `Ws-Command: terminate-session` header to a session reply channel. The websocket session, along with the connection, will get closed gracefully with code 1000 by default.
+Close details can be customized by providing `Ws-Close-Code` and `Ws-Close-Reason` headers.
+
+```http
+POST /reply/550e8400-e29b-41d4-a716-446655440000 HTTP/1.1
+Host: ws2wh-host:3000
+Ws-Command: terminate-session
+Ws-Close-Code: 1000
+Ws-Close-Reason: "Closing connection"
+```
+
+`Ws-Close-Code` value can be any integer value, although it is recommended to use one of the [standard close codes](https://www.rfc-editor.org/rfc/rfc6455#section-7.4). `Ws-Close-Reason` is a string value that will be sent to the WebSocket client.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -253,6 +253,11 @@ func GetCloseCode(headerVal string) (int, error) {
 		return 0, fmt.Errorf("close code must be between 1000 and 4999")
 	}
 
+	switch closeCode {
+	case 1004, 1005, 1006, 1015:
+		return 0, fmt.Errorf("close code %d is reserved and must not be sent", closeCode)
+	}
+
 	return int(closeCode), nil
 }
 

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -173,7 +173,7 @@ func (s *testSessionHandle) Send(payload []byte) error {
 	s.sendCount += 1
 	return nil
 }
-func (s *testSessionHandle) Close() error {
+func (s *testSessionHandle) Close(closeCode int, closeReason *string) error {
 	s.closeCount += 1
 	return nil
 }

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -200,6 +200,10 @@ func TestGetCloseCodeInvalid(t *testing.T) {
 		"999",
 		"5000",
 		"A",
+		"1004",
+		"1005",
+		"1006",
+		"1015",
 	}
 
 	for _, headerVal := range invalidHeaderVals {

--- a/frontend/wshandler.go
+++ b/frontend/wshandler.go
@@ -70,12 +70,13 @@ func (h *WebsocketHandler) Signal() <-chan session.ConnectionSignal {
 }
 
 // Close gracefully terminates the WebSocket connection
-func (h *WebsocketHandler) Close() error {
+func (h *WebsocketHandler) Close(closeCode int, closeReason *string) error {
 	h.signalChannel <- session.ConnectionClosedSignal
 
 	h.closed = true
 
-	err := h.conn.WriteMessage(websocket.CloseMessage, make([]byte, 0))
+	closeMessage := websocket.FormatCloseMessage(closeCode, *closeReason)
+	err := h.conn.WriteMessage(websocket.CloseMessage, closeMessage)
 	if err != nil {
 		return err
 	}

--- a/frontend/wshandler.go
+++ b/frontend/wshandler.go
@@ -81,13 +81,18 @@ func (h *WebsocketHandler) Close(closeCode int, closeReason *string) error {
 	defer func() {
 		err := h.conn.Close()
 		if err != nil {
-			slog.Error("Error while closing connection", "error", err)
+			h.logger.Error("Error while closing connection", "error", err)
 		}
 	}()
 
 	h.signalChannel <- session.ConnectionClosedSignal
 
-	closeMessage := websocket.FormatCloseMessage(closeCode, *closeReason)
+	var reason string
+	if closeReason != nil {
+		reason = *closeReason
+	}
+
+	closeMessage := websocket.FormatCloseMessage(closeCode, reason)
 	err := h.conn.WriteMessage(websocket.CloseMessage, closeMessage)
 	if err != nil {
 		return err

--- a/server/server.go
+++ b/server/server.go
@@ -175,6 +175,7 @@ func (s *Server) send(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(SessionResponse{Success: false, Message: "INVALID_REQUEST"})
 		return
 	}
+	defer r.Body.Close()
 
 	session := s.getSession(id)
 	if session == nil {

--- a/server/server.go
+++ b/server/server.go
@@ -197,11 +197,17 @@ func (s *Server) send(w http.ResponseWriter, r *http.Request) {
 		closeCode, err := backend.GetCloseCode(r.Header.Get(backend.CloseCodeHeader))
 		if err != nil {
 			slog.Error("Error while getting close code", "error", err)
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(SessionResponse{Success: false, Message: "INVALID_CLOSE_CODE"})
+			return
 		}
 
 		closeReason, err := backend.GetCloseReason(r.Header.Get(backend.CloseReasonHeader))
 		if err != nil {
 			slog.Error("Error while getting close reason", "error", err)
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(SessionResponse{Success: false, Message: "INVALID_CLOSE_REASON"})
+			return
 		}
 
 		err = session.Close(closeCode, closeReason)

--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -194,7 +195,12 @@ func (s *Server) send(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Header.Get(backend.CommandHeader) == backend.TerminateSessionCommand {
-		err := session.Close()
+		closeCode, err := strconv.ParseInt(r.Header.Get(backend.CloseCodeHeader), 10, 32)
+		if err != nil {
+			slog.Error("Error while parsing close code", "error", err)
+		}
+		closeReason := r.Header.Get(backend.CloseReasonHeader)
+		err = session.Close(int(closeCode), &closeReason)
 
 		if err != nil {
 			slog.Error("Error while closing session", "error", err)

--- a/session/session.go
+++ b/session/session.go
@@ -52,7 +52,11 @@ func (s *Session) Send(message []byte) error {
 // Close terminates the WebSocket connection for this session
 // Returns an error if closing the connection fails
 func (s *Session) Close(closeCode int, closeReason *string) error {
-	s.Logger.Debug("Closing WebSocket connection", "sessionId", s.Id)
+	s.Logger.Debug("Closing WebSocket connection",
+		"sessionId", s.Id,
+		"closeCode", closeCode,
+		"closeReason", closeReason,
+	)
 	return s.Connection.Close(closeCode, closeReason)
 }
 

--- a/session/session.go
+++ b/session/session.go
@@ -51,9 +51,9 @@ func (s *Session) Send(message []byte) error {
 
 // Close terminates the WebSocket connection for this session
 // Returns an error if closing the connection fails
-func (s *Session) Close() error {
+func (s *Session) Close(closeCode int, closeReason *string) error {
 	s.Logger.Debug("Closing WebSocket connection", "sessionId", s.Id)
-	return s.Connection.Close()
+	return s.Connection.Close(closeCode, closeReason)
 }
 
 // Receive handles the WebSocket session lifecycle and message flow
@@ -129,7 +129,7 @@ type WebsocketConn interface {
 	Send(payload []byte) error
 	Receiver() <-chan []byte
 	Signal() <-chan ConnectionSignal
-	Close() error
+	Close(closeCode int, closeReason *string) error
 }
 
 // SessionParams contains the configuration parameters for creating a new Session

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -20,8 +20,8 @@ type MockWebsocketConn struct {
 
 func NewMockWebsocketConn() *MockWebsocketConn {
 	return &MockWebsocketConn{
-		receiverChan: make(chan []byte),
-		doneChan:     make(chan ConnectionSignal),
+		receiverChan: make(chan []byte, 64),
+		doneChan:     make(chan ConnectionSignal, 64),
 	}
 }
 

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -38,7 +38,7 @@ func (m *MockWebsocketConn) Signal() <-chan ConnectionSignal {
 	return m.doneChan
 }
 
-func (m *MockWebsocketConn) Close() error {
+func (m *MockWebsocketConn) Close(closeCode int, closeReason *string) error {
 	m.closeCalled = true
 	return m.closeError
 }
@@ -85,7 +85,7 @@ func TestSession_Close(t *testing.T) {
 	conn := NewMockWebsocketConn()
 	session := &Session{Connection: conn, Logger: *slog.Default()}
 
-	err := session.Close()
+	err := session.Close(1000, nil)
 
 	assert.NoError(t, err, "Close should not return error")
 	assert.True(t, conn.closeCalled, "Close should be called on WebsocketConn")

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -23,7 +23,7 @@ type MockWebsocketConn struct {
 func NewMockWebsocketConn() *MockWebsocketConn {
 	return &MockWebsocketConn{
 		receiverChan: make(chan []byte, 64),
-		doneChan:     make(chan ConnectionSignal, 64),
+		doneChan:     make(chan ConnectionSignal),
 	}
 }
 
@@ -113,15 +113,13 @@ func TestSession_Receive(t *testing.T) {
 
 	// Test connection message
 	go func() {
+		defer close(conn.doneChan)
 		// Simulate ready signal
 		conn.doneChan <- ConnectionReadySignal
 		// Simulate message received
 		conn.receiverChan <- []byte("test message")
 		// Simulate closed signal
 		conn.doneChan <- ConnectionClosedSignal
-
-		// Then simulate connection close
-		close(conn.doneChan)
 	}()
 
 	session.Receive()

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/ws2wh/ws2wh/backend"
@@ -100,6 +101,7 @@ func TestSession_Close(t *testing.T) {
 	}
 }
 
+// Test is flaky
 func TestSession_Receive(t *testing.T) {
 	conn := NewMockWebsocketConn()
 	mockBackend := &MockBackend{}
@@ -113,16 +115,21 @@ func TestSession_Receive(t *testing.T) {
 
 	// Test connection message
 	go func() {
-		defer close(conn.doneChan)
 		// Simulate ready signal
 		conn.doneChan <- ConnectionReadySignal
+		time.Sleep(time.Millisecond * 100)
 		// Simulate message received
 		conn.receiverChan <- []byte("test message")
+		time.Sleep(time.Millisecond * 100)
 		// Simulate closed signal
 		conn.doneChan <- ConnectionClosedSignal
+		time.Sleep(time.Millisecond * 100)
+		close(conn.doneChan)
 	}()
 
 	session.Receive()
+
+	time.Sleep(time.Second * 2)
 
 	// Verify messages sent to backend
 	assert.Len(t, mockBackend.messages, 3, "Should have 3 backend messages")

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -144,7 +144,7 @@ func sessionTerminatedByBackend(conn *websocket.Conn, replyUrl string, t *testin
 
 	expectedDataPayload := []byte(uuid.NewString())
 	expectedCloseReason := "test reason"
-	req, _ := http.NewRequest(http.MethodPost, replyUrl, bytes.NewReader([]byte(expectedDataPayload)))
+	req, _ := http.NewRequest(http.MethodPost, replyUrl, bytes.NewReader(expectedDataPayload))
 
 	req.Header = http.Header{
 		backend.CommandHeader:     {backend.TerminateSessionCommand},

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -93,7 +93,7 @@ func websocketClientMessageSent(conn *websocket.Conn, wh *TestWebhook, sessionId
 func backendMessageSent(conn *websocket.Conn, replyUrl string, t *testing.T) {
 	assert := assert.New(t)
 
-	wsClientChan := make(chan []byte, 1)
+	wsClientChan := make(chan []byte, 64)
 	defer close(wsClientChan)
 	go captureMessage(conn, wsClientChan)
 
@@ -115,7 +115,7 @@ func websocketClientMessageWithImmediateBackendResponse(conn *websocket.Conn, wh
 	assert := assert.New(t)
 	expectedResponse := []byte(uuid.NewString())
 	wh.responses = append(wh.responses, expectedResponse)
-	wsClientChan := make(chan []byte, 1)
+	wsClientChan := make(chan []byte, 64)
 	defer close(wsClientChan)
 	go captureMessage(conn, wsClientChan)
 	websocketClientMessageSent(conn, wh, sessionId, "", t)
@@ -152,8 +152,8 @@ func sessionTerminatedByBackend(conn *websocket.Conn, replyUrl string, t *testin
 		backend.CloseReasonHeader: {expectedCloseReason},
 	}
 
-	messageType := make(chan int)
-	messageData := make(chan []byte)
+	messageType := make(chan int, 64)
+	messageData := make(chan []byte, 64)
 	var closed bool
 
 	go func() {

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// May be increased e.g. for debugging
-	TestTimeout = time.Second * 2
+	TestTimeout = time.Second * 5
 )
 
 // TestWebsocketToWebhook tests the full flow of WebSocket to webhook communication

--- a/tests/testwebhook.go
+++ b/tests/testwebhook.go
@@ -22,7 +22,7 @@ type TestWebhook struct {
 func CreateTestWebhook() *TestWebhook {
 	httpHandler := mux.NewRouter()
 	b := TestWebhook{
-		messages:    make(chan backend.BackendMessage, 100),
+		messages:    make(chan backend.BackendMessage, 128),
 		httpHandler: httpHandler,
 		responses:   make([][]byte, 0),
 		server:      nil,


### PR DESCRIPTION
Support for connection close codes initiated by backend service. Supports both: immediate response (via direct HTTP response content/headers) and asynchronous connection termination initiated entirely by the backend service.

Connection termination details can be set using the following headers:
- `Ws-Close-Code`
- `Ws-Close-Reason`

Headers should be combined with `Ws-Command: terminate-session` command, otherwise will be ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - WebSocket sessions can be terminated with an explicit close code and UTF-8 reason; clients receive close frames. Invalid close inputs now yield clear error responses. Default code is 1000; range/recommendations documented.

- Documentation
  - README expanded with new flags/env vars, protocol flow, headers (Ws-Event, Ws-Close-Code, Ws-Close-Reason), examples, and detailed termination semantics.

- Tests
  - Unit and integration tests updated to validate close code/reason parsing, two-step payload-then-close flows, and termination signaling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->